### PR TITLE
displaying alternate forms for new item via the shopping list

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :find_item, only: [:edit, :update, :destroy, :add_to_list]
 
   def new
+    @existing_items = current_user.pantry.items.where(shopping_list: nil)
     @item = Item.new
   end
 
@@ -11,6 +12,9 @@ class ItemsController < ApplicationController
       @item.pantry = current_user.pantry
       below_threshold?
     elsif params[:previous_page].include? "/shopping_list"
+      if params[:item][:id]
+        @item = Item.find(params[:item][:id])
+      end
       @item.shopping_list = current_user.shopping_list
     end
     if @item.save

--- a/app/javascript/controllers/shopping_list_form_controller.js
+++ b/app/javascript/controllers/shopping_list_form_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="shopping-list-form"
+export default class extends Controller {
+  static targets = ["newForm", "existingItems", "button"]
+
+  connect() {
+    console.log("Hello from the Shopping List Form Controller!")
+  }
+
+  revealForm() {
+    this.existingItemsTarget.classList.add("d-none")
+    this.buttonTarget.classList.add("d-none")
+    this.newFormTarget.classList.remove("d-none")
+  }
+}

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,1 +1,15 @@
-<%= render "form", item: @item %>
+<% if request.referer.include? "/shopping_list" %>
+  <div class="shopping-new-container" data-controller="shopping-list-form">
+    <%= simple_form_for @item, data: { shopping_list_form_target: "existingItems"} do |f| %>
+      <%= f.input :id, label: "Select an existing item:", collection: @existing_items, label_method: :name, value_method: :id, prompt: "Select an item" %>
+      <%= hidden_field_tag :previous_page, request.referer %>
+      <%= f.submit %>
+    <% end %>
+    <button class="btn btn-primary" data-action="shopping-list-form#revealForm" data-shopping-list-form-target="button">New item</button>
+    <div class="d-none" data-shopping-list-form-target="newForm">
+      <%= render "form", item: @item%>
+    </div>
+  </div>
+<% else %>
+  <%= render "form", item: @item %>
+<% end %>


### PR DESCRIPTION
If a user accesses the new item action via the shopping list they are now given the option to select from pre-existing items in the pantry. OR create a new item from scratch. A stimulus controller was created to handle this